### PR TITLE
分离分布填表的填表和聊天注入逻辑

### DIFF
--- a/scripts/runtime/separateTableUpdate.js
+++ b/scripts/runtime/separateTableUpdate.js
@@ -137,6 +137,8 @@ export async function TableTwoStepSummary(mode, messageContent = null) {
  * @param {boolean} shouldReload - 是否在完成后刷新页面。
  */
 export async function manualSummaryChat(todoChats, confirmResult, shouldReload = true) {
+    // 设置一个旗标，用于在onChatCompletionPromptReady中判断是否为填表请求
+    DERIVED.any.isAITableFillingRequest = true;
     // 步骤一：检查是否需要执行“撤销”操作
     // 首先获取当前的聊天片段，以判断表格状态
     const { piece: initialPiece } = USER.getChatPiece();

--- a/scripts/settings/userExtensionSetting.js
+++ b/scripts/settings/userExtensionSetting.js
@@ -299,7 +299,7 @@ function InitBinging() {
     $("#fill_table_time").change(function() {
         const value = $(this).val();
         const step_by_step = value === 'after'
-        $('#reply_options').toggle(!step_by_step);
+        $('#reply_options').show();
         $('#step_by_step_options').toggle(step_by_step);
         USER.tableBaseSetting.step_by_step = step_by_step;
     })
@@ -586,7 +586,7 @@ export function renderSetting() {
     updateSwitch('#alternate_switch', USER.tableBaseSetting.alternate_switch);
     updateSwitch('#show_drawer_in_extension_list', USER.tableBaseSetting.show_drawer_in_extension_list);
     updateSwitch('#table_to_chat_can_edit', USER.tableBaseSetting.table_to_chat_can_edit);
-    $('#reply_options').toggle(!USER.tableBaseSetting.step_by_step);
+    $('#reply_options').show();
     $('#step_by_step_options').toggle(USER.tableBaseSetting.step_by_step);
     $('#table_to_chat_options').toggle(USER.tableBaseSetting.isTableToChat);
     $('#table_to_chat_is_micro_d').toggle(USER.tableBaseSetting.table_to_chat_mode === 'macro');


### PR DESCRIPTION
分离分布填表的填表和聊天注入逻辑

当前分布填表有两个步骤，分别是**聊天请求**和**填表请求**，但是在当前代码中没有分离二者的注入逻辑，聊天请求中会根据同时填表的注入设置去将表格注入到请求中，这会导致**预设结构被表格破坏**，造成预设能力下降，甚至**破限失败**！

这个pr添加了一个用于判断是否在填表的flag以分离聊天和填表的注入逻辑